### PR TITLE
Bug fix: Fix Collection failed test

### DIFF
--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace SikaradevPhpUtils\Helper\Test\Collections;
+namespace SikaradevPhpUtils\Test\Collections;
 
 use PHPUnit\Framework\TestCase;
-use SikaradevPhpUtils\Helper\Collections\Collection;
+use SikaradevPhpUtils\Collections\Collection;
 
 class CollectionTest extends TestCase
 {
@@ -20,9 +20,14 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, Collection::of([]));
     }
 
+    /**
+     * @group test
+     */
     public function testFilter()
     {
-        $response = $this->collection->filter(fn(int $k, string $v) => $k == 1);
+        $response = $this->collection
+            ->filter(fn(int $k, string $v) => $k == 1)
+            ->get();
         $this->assertIsArray($response);
         $this->assertCount(1, $response);
         $this->assertEquals(['data/country.json'], $response);
@@ -31,7 +36,8 @@ class CollectionTest extends TestCase
     public function test_it_should_return_empty_array()
     {
         $response = Collection::of([])
-            ->filter(fn(int $k, string $v) => $k == 1);
+            ->filter(fn(int $k, string $v) => $k == 1)
+            ->get();
         $this->assertIsArray($response);
         $this->assertEmpty($response);
     }


### PR DESCRIPTION
Functions testFilter and test_it_should_return_empty_array are failed because filter function return the Collection but not an array.